### PR TITLE
Add random scenario generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@
     &nbsp;&nbsp;|&nbsp;&nbsp;
     <button id="downloadJSON">Download</button>
     <button id="clearScene">Clear Scene</button>
+    <button id="randomScenario">Random Terrain</button>
   </div>
   <canvas id="c"></canvas>
   </div>

--- a/js/main.js
+++ b/js/main.js
@@ -359,7 +359,8 @@ document.addEventListener('DOMContentLoaded', () => {
       updateSceneElements,
       rebuild,
       updateEnvironment,
-      toggleGridVisibility
+      toggleGridVisibility,
+      createRandomScenario
     },
     // Dependencies
     {
@@ -714,6 +715,24 @@ document.addEventListener('DOMContentLoaded', () => {
     // Hide all indicators when resetting
     lastPoleIndicator.visible = false;
     lastPoleInnerIndicator.visible = false;
+  }
+
+  function createRandomScenario() {
+    const terrainChoices = ['flat', 'hills', 'hillsTrees'];
+    const choice = terrainChoices[Math.floor(Math.random() * terrainChoices.length)];
+    if (elements.terrainSelect) {
+      elements.terrainSelect.value = choice;
+      elements.terrainSelect.onchange();
+    } else {
+      resetScene();
+    }
+
+    let z = 0;
+    for (let i = 0; i < 5; i++) {
+      if (i > 0) z += THREE.MathUtils.randInt(15, 25);
+      const h = THREE.MathUtils.randInt(10, 30);
+      addPole(0, z, h);
+    }
   }
 
   window.addEventListener('resize', () => {

--- a/js/ui.js
+++ b/js/ui.js
@@ -19,7 +19,8 @@ export const elements = {
   get environmentSelect() { return document.getElementById('environmentSelect'); },
   get equipmentSelect() { return document.getElementById('equipmentSelect'); },
   get clearButton() { return document.getElementById('clearScene'); },
-  get showGridCheck() { return document.getElementById('showGridCheck'); }
+  get showGridCheck() { return document.getElementById('showGridCheck'); },
+  get randomButton() { return document.getElementById('randomScenario'); }
 };
 
 /**
@@ -46,8 +47,8 @@ export function initUI() {
  * This should be called after all dependencies are available
  */
 export function setupUI(callbacks, dependencies) {
-  const { updateGhost, clearSceneElements, resetScene, updateSceneElements, 
-          rebuild, updateEnvironment, toggleGridVisibility } = callbacks;
+  const { updateGhost, clearSceneElements, resetScene, updateSceneElements,
+          rebuild, updateEnvironment, toggleGridVisibility, createRandomScenario } = callbacks;
           
   const { scene, trees, treeData, urlParams, customPoles, SEG, hAt, 
           addGridLines, addDefaultTrees, importedBuildTerrain } = dependencies;
@@ -115,6 +116,11 @@ export function setupUI(callbacks, dependencies) {
   
   // Clear button
   elements.clearButton.onclick = resetScene;
+
+  // Random scenario button
+  if (elements.randomButton) {
+    elements.randomButton.onclick = createRandomScenario;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a **Random Terrain** button to create a random scenario
- wire the button up through `ui.js`
- implement random scenario generation in `main.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f794426a88327b4884f34ecaf6d3d